### PR TITLE
RACSignal+Operations: Fix -sample behavior.

### DIFF
--- a/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoa/RACSignal+Operations.h
@@ -623,7 +623,8 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
 /// the receiver. Values from `sampler` are ignored before the receiver sends
-/// its first value.
+/// its first value. The signal completes once both the receiver and `sampler`
+/// complete or errs if either the recevier or `sampler` err.
 ///
 /// sampler - The signal that controls when the latest value from the receiver
 ///           is sent. Cannot be nil.

--- a/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoa/RACSignal+Operations.m
@@ -1236,6 +1236,8 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		NSLock *lock = [[NSLock alloc] init];
 		__block id lastValue;
 		__block BOOL hasValue = NO;
+		__block BOOL selfCompleted = NO;
+		__block BOOL samplerCompleted = NO;
 
 		RACSerialDisposable *samplerDisposable = [[RACSerialDisposable alloc] init];
 		RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
@@ -1247,8 +1249,16 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 			[samplerDisposable dispose];
 			[subscriber sendError:error];
 		} completed:^{
-			[samplerDisposable dispose];
-			[subscriber sendCompleted];
+			BOOL shouldComplete = NO;
+			[lock lock];
+			selfCompleted = YES;
+			shouldComplete = samplerCompleted;
+			[lock unlock];
+
+			if (shouldComplete) {
+				[samplerDisposable dispose];
+				[subscriber sendCompleted];
+			}
 		}];
 
 		samplerDisposable.disposable = [sampler subscribeNext:^(id _) {
@@ -1266,8 +1276,16 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 			[sourceDisposable dispose];
 			[subscriber sendError:error];
 		} completed:^{
-			[sourceDisposable dispose];
-			[subscriber sendCompleted];
+			BOOL shouldComplete = NO;
+			[lock lock];
+			samplerCompleted = YES;
+			shouldComplete = selfCompleted;
+			[lock unlock];
+
+			if (shouldComplete) {
+				[sourceDisposable dispose];
+				[subscriber sendCompleted];
+			}
 		}];
 
 		return [RACDisposable disposableWithBlock:^{

--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -3156,10 +3156,17 @@ qck_describe(@"+zip:", ^{
 });
 
 qck_describe(@"-sample:", ^{
+	__block RACSubject *subject;
+	__block RACSubject *sampleSubject;
+	__block RACSignal *sampled;
+
+	qck_beforeEach(^{
+		subject = [RACSubject subject];
+		sampleSubject = [RACSubject subject];
+		sampled = [subject sample:sampleSubject];
+	});
+
 	qck_it(@"should send the latest value when the sampler signal fires", ^{
-		RACSubject *subject = [RACSubject subject];
-		RACSubject *sampleSubject = [RACSubject subject];
-		RACSignal *sampled = [subject sample:sampleSubject];
 		NSMutableArray *values = [NSMutableArray array];
 		[sampled subscribeNext:^(id x) {
 			[values addObject:x];
@@ -3186,6 +3193,32 @@ qck_describe(@"-sample:", ^{
 		[sampleSubject sendNext:RACUnit.defaultUnit];
 		expected = @[ @2, @3, @3 ];
 		expect(values).to(equal(expected));
+	});
+
+	qck_it(@"should not complete before sampler completes", ^{
+		__block BOOL hasCompleted = NO;
+		[sampled subscribeCompleted:^{
+			hasCompleted = YES;
+		}];
+
+		[subject sendCompleted];
+		expect(@(hasCompleted)).to(beFalsy());
+
+		[sampleSubject sendCompleted];
+		expect(@(hasCompleted)).to(beTruthy());
+	});
+
+	qck_it(@"should not complete before the receiver completes", ^{
+		__block BOOL hasCompleted = NO;
+		[sampled subscribeCompleted:^{
+			hasCompleted = YES;
+		}];
+
+		[sampleSubject sendCompleted];
+		expect(@(hasCompleted)).to(beFalsy());
+
+		[subject sendCompleted];
+		expect(@(hasCompleted)).to(beTruthy());
 	});
 });
 


### PR DESCRIPTION
The -sample operator completes once the receiver completes. This behavior is not suited for this particular operator, which should more likely complete once the both sampler and the sampled signals complete, truly indicating it will not send any more values.
Both signals still pass through errors.